### PR TITLE
[IR]メッセージ画面のスクロールを実装する。

### DIFF
--- a/chat-space/app/assets/javascripts/message.js
+++ b/chat-space/app/assets/javascripts/message.js
@@ -13,7 +13,7 @@ $(function() {
         e.preventDefault();
         var formData = new FormData(this);
         $.ajax({
-          url: url,
+          url: $(this).attr('action'),
           type: "POST",
           data: formData,
           dataType: 'json',
@@ -21,7 +21,7 @@ $(function() {
           contentType: false
         });
 
-        done(function(data) {
+        .done(function(data) {
           var html = buildHTML(data);
           $('.messages').append(html)
           // $('.textbox').val('')

--- a/chat-space/app/assets/javascripts/message.js
+++ b/chat-space/app/assets/javascripts/message.js
@@ -1,8 +1,10 @@
 $(function() {
-      function buildHTML(message) {
-        var html = `<%= render :partial => "message" %>`
-        return html;
-      };
+      // function buildHTML(message) {
+      //   // var html = "<%= render :partial => 'message' %>"
+      //   // var html = "<h1>test</h1>"
+      //   var html = ""
+      //   return html;
+      // };
 
       // $(function(){
       // setInterval(update, 10000);
@@ -21,13 +23,20 @@ $(function() {
           contentType: false
         })
         .done(function(data){
-          console.log($('.textArea')[0].scrollHeight)
-          console.log('done')
-          var html = buildHTML(data);
-          $('.messages').append(html)
+          console.log($('.textArea')[0].scrollHeight);
+          console.log('done1');
+          // var html = buildHTML(data);
+          var html = "<%= escape_javascript render (:partial => 'message') %>" ;
+          console.log(html);
+          // $('.messages').append(html)これは間違い。
+          $('.textArea').append(html);
+          // $('.textArea').append('<h2>test</h2>');部分テンプレートが読み込まれない…文字列として表示されてしまうが、これは文字列ではない。
+          // $('.textArea').html(<%= j (render @messages) %>); 記法のエラーなのでこれ以降実行されないが、表示はうまくいく。
           // $('.textbox').val('')
-          $('.textbox').reset();
+          $('.sendMessage__input-text').val('');
+          // $('.textbox').reset();
           $('.textArea').animate({scrollTop: $('.textArea')[0].scrollHeight}, 'fast');
+          console.log('done');
         })
         .fail(function(XMLHttpRequest,textStatus,errorThrown){
           alert('error');

--- a/chat-space/app/assets/javascripts/message.js
+++ b/chat-space/app/assets/javascripts/message.js
@@ -73,7 +73,12 @@ $(function() {
           // $('.textArea').html(<%= j (render @messages) %>); 記法のエラーなのでこれ以降実行されないが、表示はうまくいく。
           // $('.textbox').val('')
           $('.sendMessage__input-text').val('');
-          // $('.textbox').reset();
+          // $('sendMessage__input-text').reset();
+          //reset reset is not a functionとなる。名前で競合
+          // $form = $($.rails.formSubmitSelector)
+          // $.rails.enableFormElements($form)
+          // $form.reset();
+          $('.sendMessage__input-btn').prop('disabled', false);
           $('.textArea').animate({scrollTop: $('.textArea')[0].scrollHeight}, 'fast');
           console.log('done');
         })

--- a/chat-space/app/assets/javascripts/message.js
+++ b/chat-space/app/assets/javascripts/message.js
@@ -1,14 +1,5 @@
 $(function() {
       function buildHTML(message) {
-        // var html = `<%= render :partial => 'message' %>`;
-        // var html = "<h1>test</h1>"
-        console.log(message);
-        console.log(message.message.user);
-        console.log(message.message.user.name);
-        console.log(message.message.created_at);
-        console.log(message.message.text);
-        console.log(message.message.image);
-        console.log(message.message);
         var user_name = message.message.user.name;
         var post_time = message.message.created_at;
         var content_text = ``;
@@ -17,14 +8,11 @@ $(function() {
           content_text = `
           <p class="textArea__message">
             ${message.message.text}
-          </p>
-          `;
-        }
-
+          </p>`;
+        };
         if(message.message.image){
           content_image = `<img href="message.image.url" class="textArea__image">`;
-        }
-
+        };
         var html = `
           <div class="textArea_box">
             <div class="textArea__user">
@@ -37,16 +25,9 @@ $(function() {
               ${content_text}
               ${content_image}
             </div>
-          </div>`
-        ;
+          </div>`;
         return html;
       };
-
-      // $(function(){
-      // setInterval(update, 10000);
-      // 10000ミリ秒ごとにupdateという関数を実行する
-      // });
-
       $('#new_message').on('submit', function(e) {
         e.preventDefault();
         var formData = new FormData(this);
@@ -59,25 +40,9 @@ $(function() {
           contentType: false
         })
         .done(function(data){
-          console.log($('.textArea')[0].scrollHeight);
-          console.log('done1');
-          // console.log(data.message);
-          // console.log(@message);
           var html = buildHTML(data);
-          // var html = `<%= escape_javascript render :partial => "message", locals:{message: ${data.message}} %>`;
-          //部分テンプレートを使用して簡略化しようと思ったが、なぜかうまくいかない…
-          console.log(html);
-          // $('.messages').append(html)これは間違い。
           $('.textArea').append(html);
-          // $('.textArea').append('<h2>test</h2>');部分テンプレートが読み込まれない…文字列として表示されてしまうが、これは文字列ではない。
-          // $('.textArea').html(<%= j (render @messages) %>); 記法のエラーなのでこれ以降実行されないが、表示はうまくいく。
-          // $('.textbox').val('')
           $('.sendMessage__input-text').val('');
-          // $('sendMessage__input-text').reset();
-          //reset reset is not a functionとなる。名前で競合
-          // $form = $($.rails.formSubmitSelector)
-          // $.rails.enableFormElements($form)
-          // $form.reset();
           $('.sendMessage__input-btn').prop('disabled', false);
           $('.textArea').animate({scrollTop: $('.textArea')[0].scrollHeight}, 'fast');
           console.log('done');

--- a/chat-space/app/assets/javascripts/message.js
+++ b/chat-space/app/assets/javascripts/message.js
@@ -61,9 +61,10 @@ $(function() {
         .done(function(data){
           console.log($('.textArea')[0].scrollHeight);
           console.log('done1');
+          // console.log(data.message);
           // console.log(@message);
           var html = buildHTML(data);
-          // var html = '<%= escape_javascript render :partial => "message", locals:{message: ${message}} %>';
+          // var html = `<%= escape_javascript render :partial => "message", locals:{message: ${data.message}} %>`;
           //部分テンプレートを使用して簡略化しようと思ったが、なぜかうまくいかない…
           console.log(html);
           // $('.messages').append(html)これは間違い。

--- a/chat-space/app/assets/javascripts/message.js
+++ b/chat-space/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function() {
       function buildHTML(message) {
         var html = `<%= render :partial => "message" %>`
         return html;
-      }
+      };
 
       // $(function(){
       // setInterval(update, 10000);
@@ -19,16 +19,24 @@ $(function() {
           dataType: 'json',
           processData: false,
           contentType: false
-        });
-
-        .done(function(data) {
+        })
+        .done(function(data){
+          console.log($('.textArea')[0].scrollHeight)
+          console.log('done')
           var html = buildHTML(data);
           $('.messages').append(html)
           // $('.textbox').val('')
           $('.textbox').reset();
-        });
-        fail(function(){
+          $('.textArea').animate({scrollTop: $('.textArea')[0].scrollHeight}, 'fast');
+        })
+        .fail(function(XMLHttpRequest,textStatus,errorThrown){
           alert('error');
+          console.log(XMLHttpRequest.status);
+          console.log(textStatus);
+          console.log(errorThrown);
+        })
+        .always(function(){
+          console.log('always log');
         });
 
       });

--- a/chat-space/app/assets/javascripts/message.js
+++ b/chat-space/app/assets/javascripts/message.js
@@ -1,10 +1,46 @@
 $(function() {
-      // function buildHTML(message) {
-      //   // var html = "<%= render :partial => 'message' %>"
-      //   // var html = "<h1>test</h1>"
-      //   var html = ""
-      //   return html;
-      // };
+      function buildHTML(message) {
+        // var html = `<%= render :partial => 'message' %>`;
+        // var html = "<h1>test</h1>"
+        console.log(message);
+        console.log(message.message.user);
+        console.log(message.message.user.name);
+        console.log(message.message.created_at);
+        console.log(message.message.text);
+        console.log(message.message.image);
+        console.log(message.message);
+        var user_name = message.message.user.name;
+        var post_time = message.message.created_at;
+        var content_text = ``;
+        var content_image = ``;
+        if(message.message.text){
+          content_text = `
+          <p class="textArea__message">
+            ${message.message.text}
+          </p>
+          `;
+        }
+
+        if(message.message.image){
+          content_image = `<img href="message.image.url" class="textArea__image">`;
+        }
+
+        var html = `
+          <div class="textArea_box">
+            <div class="textArea__user">
+              <h3 class="textArea__name">
+                ${user_name}
+                <span class="textArea__timestamp">
+                  ${post_time}
+                </span>
+              </h3>
+              ${content_text}
+              ${content_image}
+            </div>
+          </div>`
+        ;
+        return html;
+      };
 
       // $(function(){
       // setInterval(update, 10000);
@@ -25,8 +61,10 @@ $(function() {
         .done(function(data){
           console.log($('.textArea')[0].scrollHeight);
           console.log('done1');
-          // var html = buildHTML(data);
-          var html = "<%= escape_javascript render (:partial => 'message') %>" ;
+          // console.log(@message);
+          var html = buildHTML(data);
+          // var html = '<%= escape_javascript render :partial => "message", locals:{message: ${message}} %>';
+          //部分テンプレートを使用して簡略化しようと思ったが、なぜかうまくいかない…
           console.log(html);
           // $('.messages').append(html)これは間違い。
           $('.textArea').append(html);

--- a/chat-space/app/assets/stylesheets/module/_base.scss
+++ b/chat-space/app/assets/stylesheets/module/_base.scss
@@ -3,3 +3,7 @@
     display: block;
     clear: both;
 }
+
+.box_in_scroll{
+  overflow: scroll;
+}

--- a/chat-space/app/controllers/messages_controller.rb
+++ b/chat-space/app/controllers/messages_controller.rb
@@ -19,7 +19,7 @@ class MessagesController < ApplicationController
         flash.now[:alert] = 'メッセージを入力してください...'
         render :index
       end
-       end
+    end
   end
 
   private

--- a/chat-space/app/views/devise/shared/_sidebar.haml
+++ b/chat-space/app/views/devise/shared/_sidebar.haml
@@ -9,7 +9,7 @@
         %li.list
           = link_to edit_user_path(current_user) do
             %i.fa.icon.fa-cog
-  .sideBar__groups
+  .sideBar__groups.box_in_scroll
     - current_user.groups.each do |g|
       .sideBar__group
         = link_to group_messages_path(g.id) do

--- a/chat-space/app/views/messages/_main_message.haml
+++ b/chat-space/app/views/messages/_main_message.haml
@@ -15,11 +15,4 @@
     = form_for [@group, @message] do |f|
       = f.text_field :content, class: 'sendMessage__input-text sendMessage__float-left textbox',placeholder: 'type a message'
       = f.submit 'Send', class: 'sendMessage__input-btn sendMessage__float-right'
-  -# .sendMessage.clearfix
-  -#   = form_for [@group, @message] do |f|
-  -#     = f.text_field :content, class: 'sendMessage__input-text sendMessage__float-left textbox',placeholder: 'type a message'
-  -#       .sendMessage__input-icon
-  -#         = f.label :image, class: 'sendMessage__mask__image' do
-  -#           %i.fa.icon.fa-image
-  -#           = f.file_field :image, class: 'hidden'
-  -#     = f.submit 'Send', class: 'sendMessage__input-btn sendMessage__float-right'
+  

--- a/chat-space/app/views/messages/_main_message.haml
+++ b/chat-space/app/views/messages/_main_message.haml
@@ -8,7 +8,7 @@
           = @group.members.name
     %a.info__edit-btn.info__float-right
       Edit
-  .textArea
+  .textArea.box_in_scroll
     = render @messages, collection: @messages, as: :message
 
   .sendMessage.clearfix

--- a/chat-space/app/views/messages/_main_message.haml
+++ b/chat-space/app/views/messages/_main_message.haml
@@ -15,4 +15,3 @@
     = form_for [@group, @message] do |f|
       = f.text_field :content, class: 'sendMessage__input-text sendMessage__float-left textbox',placeholder: 'type a message'
       = f.submit 'Send', class: 'sendMessage__input-btn sendMessage__float-right'
-  

--- a/chat-space/app/views/messages/create.json.jbuilder
+++ b/chat-space/app/views/messages/create.json.jbuilder
@@ -1,9 +1,9 @@
-json.id @message.id
-json.user_id @message.user_id
-json.text @message.content
-# json.user.name @message.user.name
-json.created_at @message.created_at
-
-# use_name = User.find(@message.user_id)
-
-json.user(@message.user, :name)
+json.set! :message do
+  json.id @message.id
+  json.user_id @message.user_id
+  json.text @message.content
+  # json.user.name @message.user.name
+  json.created_at @message.created_at
+  # use_name = User.find(@message.user_id)
+  json.user(@message.user, :name)
+end

--- a/chat-space/app/views/messages/create.json.jbuilder
+++ b/chat-space/app/views/messages/create.json.jbuilder
@@ -1,5 +1,9 @@
 json.id @message.id
 json.user_id @message.user_id
-json.text @message.text
-json.user.name @message.user.name
+json.text @message.content
+# json.user.name @message.user.name
 json.created_at @message.created_at
+
+# use_name = User.find(@message.user_id)
+
+json.user(@message.user, :name)

--- a/chat-space/app/views/messages/create.json.jbuilder
+++ b/chat-space/app/views/messages/create.json.jbuilder
@@ -2,8 +2,6 @@ json.set! :message do
   json.id @message.id
   json.user_id @message.user_id
   json.text @message.content
-  # json.user.name @message.user.name
   json.created_at @message.created_at
-  # use_name = User.find(@message.user_id)
   json.user(@message.user, :name)
 end


### PR DESCRIPTION
## 実装の目的/背景
メッセージが１画面に治らない場合、スクロールで表示するようにする。
また、新規のメッセージが投稿された場合に最新のメッセージが一番したに表示され、
アニメーションで最新の投稿まで遷移する。

## 画面+機能（画面が無い場合は機能だけ）
- [x] スクロール表示
- [x] 新規メッセージが一番下に表示される
- [x] 新規メッセージが送信された場合、アニメーションで最新の投稿まで遷移する。

[![Image from Gyazo](https://i.gyazo.com/aa89993742430e89e5fe9235ecc83359.gif)](https://gyazo.com/aa89993742430e89e5fe9235ecc83359)

## 非機能要件（or 不安なこと）
部分テンプレートを呼び出そうとしていたのですが、うまくいかないです…
JSの文法エラーを出せば表示はうまくいきますが、その記述以降の実行をしてくれなくなります。

## テスト証跡
+ [x] メッセージがスクロールで表示できる
+ [x] メッセージを送信すると、一番したに追加される。
+ [x] メッセージを送信すると、最新のメッセージにアニメーションで移動する。
+ [x] 連続でメッセージを送信できる
+ [x] 表示が崩れていない。


## 関連するIssue等
#25 
メッセージの非同期通信

## レビューポイント
+ スクロールに関するところのみお願いします！
+ そのほかはまた別ブランチで作業します。

## 留意事項
+ 色々試したコードな別のブランチ `message_ajax_study` に残してあります。

## 残課題
+ リファクタ
